### PR TITLE
Add single line comment toggle & more syntax highlighting rules

### DIFF
--- a/maude.YAML-tmLanguage
+++ b/maude.YAML-tmLanguage
@@ -23,7 +23,7 @@ patterns:
   match: \b(sort|subsort|sorts|subsorts)\b
 
 - name: keyword.control.statements
-  match: \b(op|ops|var|vars|eq|ceq|rl|crl|cmb|reduce|red|rewrite|rew)\b
+  match: \b(op|ops|var|vars|eq|ceq|cmb|reduce|red|rewrite|rew)\b
 
 - name: storage.type
   match: \b(Bool|Nat|Zero|NzNat|Int|NzInt|Rat|PosRat|NzRat|Float|FiniteFloat|String|Char|Qid|List\{.+\}|NeList\{.+\}|NatList|Bool|Universal)\b

--- a/maude.sublime-build
+++ b/maude.sublime-build
@@ -1,0 +1,5 @@
+{
+  "cmd": ["maude", "$file"],
+  "file_regex": "Warning: \"(...*?)\", line ([0-9]*)",
+  "selector": "source.maude",
+}

--- a/maude.sublime-syntax
+++ b/maude.sublime-syntax
@@ -89,25 +89,35 @@ contexts:
       scope: keyword.operator.logical.maude
 
   comments:
-    # block comments begin with ***( and end with )
-    - match: '\*\*\*\('
-      scope: punctuation.definition.comment.block.begin.maude
-      push: line_block
+    # block comments begin with ***( and end with ) The book sais that block
+    # comments should allways start with ***, but --- also works as block
+    # comments, which I also feel is more natural
+    # ref end of section 2.2 https://maude.lcc.uma.es/maude321-manual-html/maude-manualch2.html
+    - match: (((\*\*\*)|(\-\-\-))\s+\()
+      captures:
+        1: punctuation.definition.comment.begin.block.maude
+      push: block_comment
 
     # single line comments begin with *** or ---
-    - match: '(\*\*\*[^\(])|(\-\-\-)'
-      scope: punctuation.definition.comment.line.maude
+    - match: (\*\*\*)|(\-\-\-)
+      scope: punctuation.definition.comment.begin.line.maude
       push: line_comment
-
 
   line_comment:
     - meta_scope: comment.line.maude
     - match: '\n'
       pop: true
 
-  line_block:
+  block_comment:
     - meta_scope: comment.block.maude
-    - match: '\s*\)\s*\n'
-      scope: punctuation.definition.comment.end.maude
+    - match: '\('
+      push: comment_presesis
+    - match: '\)'
+      scope: punctuation.definition.comment.end.block.maude
       pop: true
 
+  comment_presesis:
+    - match: '\('
+      push: comment_presesis
+    - match: '\)'
+      pop: true

--- a/maude.sublime-syntax
+++ b/maude.sublime-syntax
@@ -79,7 +79,7 @@ contexts:
       scope: constant.numeric.maude
 
   operators:
-    - match: '(:|(\-\>)|(\=\>)|\<|\>)|(\.\s*)'
+    - match: '(:|(\-\>)|(\=\>)|\<|\>)|(\.)'
       scope: keyword.operator.maude
 
     - match: '(\+|\-)'

--- a/maude.sublime-syntax
+++ b/maude.sublime-syntax
@@ -13,16 +13,22 @@ contexts:
     - include: comments
 
   main:
+    - include: entity
     - include: strings
     - include: keywords
     - include: storage
     - include: constant
     - include: operators
-    - include: entity
 
   entity:
-    - match: '(?<=(rl |crl) \[)\s*([a-zA-Z0-9\-\+\_])+(?=\s*\]\s*:\s*)'
-      scope: entity.name.function.maude
+    - match: (rl|crl)
+      scope: keyword.control.statements.maude
+    - match: \[
+      set:
+        - match: \b[A-Za-z_][A-Za-z_0-9]*\b
+          scope: entity.name.function.maude
+        - match: \]
+          pop: true
 
   strings:
     # Strings begin and end with quotes, and use backslashes as an escape

--- a/syntax_test_comments.maude
+++ b/syntax_test_comments.maude
@@ -1,0 +1,70 @@
+*** SYNTAX TEST "maude.sublime-syntax"
+
+comment.line.maude
+  punctuation.definition.comment.begin.line.maude
+
+comment.block.maude
+  punctuation.definition.comment.begin.block.maude
+  punctuation.definition.comment.end.block.maude
+
+test for single line comments
+
+    *** kjahdajkhd
+*** ^^^ punctuation.definition.comment.begin.line.maude
+*** ^^^^^^^^^^^^^^ comment.line.maude
+    --- kjahdajkhd
+*** ^^^ punctuation.definition.comment.begin.line.maude
+*** ^^^^^^^^^^^^^^ comment.line.maude
+
+
+
+Test for block comments with ---
+    --- (
+*** ^^^ punctuation.definition.comment.begin.block.maude
+*** ^^^^^ comment.block.maude
+      red double(3) .
+*** ^^^^^^^^^^^^^^^ comment.block.maude
+***   ^^^ - keyword.control
+    )
+*** ^ comment.block.maude
+*** ^ punctuation.definition.comment.end.block.maude
+
+
+Test for block comments with ***
+    --- (
+*** ^^^ punctuation.definition.comment.begin.block.maude
+*** ^^^^^ comment.block.maude
+      red double(3) .
+*** ^^^^^^^^^^^^^^^ comment.block.maude
+***   ^^^ - keyword.control
+    )
+*** ^ comment.block.maude
+*** ^ punctuation.definition.comment.end.block.maude
+
+    *** (
+*** ^^^ punctuation.definition.comment.begin.block.maude
+*** ^^^^^ comment.block.maude
+      red double(3) .
+*** ^^^^^^^^^^^^^^^ comment.block.maude
+***   ^^^ - keyword.control
+    )
+*** ^ comment.block.maude
+*** ^ punctuation.definition.comment.end.block.maude
+
+
+Test for block comments with code after the comment
+
+    *** (This is a comment ) red 1 + 1 .
+*** ^^^^^ punctuation.definition.comment.begin.block.maude
+*** ^^^^^^^^^^^^^^^^^^^^^^ comment.block.maude
+***                        ^ punctuation.definition.comment.end.block.maude
+
+    *** (This is a comment with matching ()  ((as) as)ad  c()mment) red 1 + 1 .
+*** ^^^^^ punctuation.definition.comment.begin.block.maude
+*** ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.maude
+***                                                               ^ punctuation.definition.comment.end.block.maude
+***                                                                 ^^^ keyword.control.statements.maude
+***                                                                 ^^^^^^^^^^^ - comment
+    *** (escaped charater does nothing \()) red 1 + 1 .
+*** ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.maude
+***                                         ^^^^^^^^^^^ - comment

--- a/syntax_test_module.maude
+++ b/syntax_test_module.maude
@@ -8,6 +8,8 @@ fmod EX12 is
     protecting INT .   
 *** ^^^^^^^^^^ keyword.control.imports.maude
 ***                ^ keyword.operator.maude
+***                 ^^^ - keyword.operator
+***                     Charahters after period should not be keyword.operator
     op double : Int -> Int .
 *** ^^ keyword.control.statements.maude
 ***           ^ keyword.operator.maude
@@ -25,6 +27,7 @@ fmod EX12 is
 *** ^^ keyword.control.statements.maude
 ***              ^^ keyword.operator.logical.maude
 ***                      ^ keyword.operator.maude
+***                       ^ - keyword.operator
     endfm
 *** ^^^^^ keyword.control.module.maude
 

--- a/syntax_test_module.maude
+++ b/syntax_test_module.maude
@@ -1,0 +1,34 @@
+*** SYNTAX TEST "maude.sublime-syntax"
+
+
+fmod EX12 is
+***       ^^ keyword.control.module.maude
+*** <- keyword.control.module
+   *** <- keyword.control.module.maude
+    protecting INT .   
+*** ^^^^^^^^^^ keyword.control.imports.maude
+***                ^ keyword.operator.maude
+    op double : Int -> Int .
+*** ^^ keyword.control.statements.maude
+***           ^ keyword.operator.maude
+***             ^^^ storage.type.maude
+***                 ^^ keyword.operator.maude
+***                    ^^^ storage.type.maude
+***                        ^ keyword.operator.maude
+
+    var N : Int .
+*** ^^^ keyword.control.statements.maude
+***       ^ keyword.operator.maude
+***         ^^^ storage.type.maude
+***             ^ keyword.operator.maude
+    eq double(N) = N + N . 
+*** ^^ keyword.control.statements.maude
+***              ^^ keyword.operator.logical.maude
+***                      ^ keyword.operator.maude
+    endfm
+*** ^^^^^ keyword.control.module.maude
+
+    red double(3) .
+*** ^^^ keyword.control.statements.maude
+***            ^ constant.numeric.maude
+***               ^ keyword.operator.maude

--- a/syntax_test_one.maude
+++ b/syntax_test_one.maude
@@ -1,0 +1,12 @@
+*** SYNTAX TEST "maude.sublime-syntax"
+
+    crl [separationInit] :
+    rl [separationInit] :
+    rl [separsationInit] :
+*** ^ keyword.control.statements.maude
+***     ^^^^^^^^^^^^^^^ entity.name.function.maude
+***                      ^ keyword.operator.maude
+    crl [birth] :
+*** ^^^ keyword.control.statements.maude
+***      ^^^^^ entity.name.function.maude
+***             ^ keyword.operator.maude


### PR DESCRIPTION
Unfortunately I wasn't able to solve the issue of toggling multi line comments.

* can now use Sublime Text default keybind of `Ctrl+/` to toggle comment lines
* added a `maude.sublime-syntax` file
* added a few more control statements (crl, cmb, reduce/red, rewrite/rew) based on the 3.1 manual [available from here](http://maude.cs.illinois.edu/w/index.php/Maude_download_and_installation)

copy of https://github.com/jpsikorra/maude_syntax_highlight/pull/2
